### PR TITLE
Adjust Pod to be YMOverride

### DIFF
--- a/Example-ObjC/Example-ObjC.xcodeproj/project.pbxproj
+++ b/Example-ObjC/Example-ObjC.xcodeproj/project.pbxproj
@@ -287,16 +287,16 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Example-ObjC/Pods-Example-ObjC-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Override/Override.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-Example-ObjC/Pods-Example-ObjC-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/YMOverride/YMOverride.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Override.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YMOverride.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example-ObjC/Pods-Example-ObjC-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example-ObjC/Pods-Example-ObjC-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E0DFFC038490E6D5FA675AC3 /* [CP] Embed Pods Frameworks */ = {
@@ -305,22 +305,22 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Example-ObjC-Example-ObjCTests/Pods-Example-ObjC-Example-ObjCTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Override/Override.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-Example-ObjC-Example-ObjCTests/Pods-Example-ObjC-Example-ObjCTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/YMOverride/YMOverride.framework",
 				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
-				"${BUILT_PRODUCTS_DIR}/OverrideTestSupport/OverrideTestSupport.framework",
 				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
+				"${BUILT_PRODUCTS_DIR}/YMOverrideTestSupport/YMOverrideTestSupport.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Override.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YMOverride.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OverrideTestSupport.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YMOverrideTestSupport.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example-ObjC-Example-ObjCTests/Pods-Example-ObjC-Example-ObjCTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example-ObjC-Example-ObjCTests/Pods-Example-ObjC-Example-ObjCTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example-ObjC/Example-ObjC/AppDelegate.m
+++ b/Example-ObjC/Example-ObjC/AppDelegate.m
@@ -4,7 +4,7 @@
 #import "AppDelegate.h"
 #import "Example_ObjC-Swift.h"
 #import "FirstViewController.h"
-@import Override;
+@import YMOverride;
 
 @interface AppDelegate ()
 

--- a/Example-ObjC/Example-ObjC/FirstViewController.h
+++ b/Example-ObjC/Example-ObjC/FirstViewController.h
@@ -3,7 +3,7 @@
 
 #import <UIKit/UIKit.h>
 #import "Example_ObjC-Swift.h"
-@import Override;
+@import YMOverride;
 
 @interface FirstViewController : UIViewController
 

--- a/Example-ObjC/Example-ObjC/MyFeatures.swift
+++ b/Example-ObjC/Example-ObjC/MyFeatures.swift
@@ -2,7 +2,7 @@
 // Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/Override for terms.
 
 import Foundation
-import Override
+import YMOverride
 
 //@objc public class ThemeFeatures: FeatureGroup {
 //    @objc let

--- a/Example-ObjC/Example-ObjCTests/FeatureTestSupportSpec.m
+++ b/Example-ObjC/Example-ObjCTests/FeatureTestSupportSpec.m
@@ -5,8 +5,8 @@
 
 #import <Expecta/Expecta.h>
 #import <Specta/Specta.h>
-#import <OverrideTestSupport/OverrideTestSupport-Swift.h>
-#import <OverrideTestSupport/FeatureTestSupport.h>
+#import <YMOverrideTestSupport/OverrideTestSupport-Swift.h>
+#import <YMOverrideTestSupport/FeatureTestSupport.h>
 
 SpecBegin(FeatureTestSupport)
 describe(@"Feature Test Support", ^{

--- a/Example-ObjC/Podfile
+++ b/Example-ObjC/Podfile
@@ -2,10 +2,10 @@ use_frameworks!
 platform :ios, '11.0'
 
 target 'Example-ObjC' do
-  pod 'Override', :path => '../'
+  pod 'YMOverride', :path => '../'
 
     target 'Example-ObjCTests' do
-        pod 'OverrideTestSupport', :path => '../'
+        pod 'YMOverrideTestSupport', :path => '../'
         pod 'Specta', '~> 1.0'
         pod 'Expecta', '~> 1.0'
     end

--- a/Example-ObjC/Podfile.lock
+++ b/Example-ObjC/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - Expecta (1.0.6)
-  - Override (1.1.2):
-    - Override/Features (= 1.1.2)
-  - Override/Features (1.1.2)
-  - OverrideTestSupport (1.1.2):
-    - Override (= 1.1.2)
   - Specta (1.0.7)
+  - YMOverride (2.0.0):
+    - YMOverride/Features (= 2.0.0)
+  - YMOverride/Features (2.0.0)
+  - YMOverrideTestSupport (2.0.0):
+    - YMOverride (= 2.0.0)
 
 DEPENDENCIES:
   - Expecta (~> 1.0)
-  - Override (from `../`)
-  - OverrideTestSupport (from `../`)
   - Specta (~> 1.0)
+  - YMOverride (from `../`)
+  - YMOverrideTestSupport (from `../`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -19,17 +19,17 @@ SPEC REPOS:
     - Specta
 
 EXTERNAL SOURCES:
-  Override:
+  YMOverride:
     :path: "../"
-  OverrideTestSupport:
+  YMOverrideTestSupport:
     :path: "../"
 
 SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  Override: 47dd9518f1194b281094db1cd5cb6a0ecf27c1cf
-  OverrideTestSupport: f47690c6f0e4ef37bf209ec5e508cbf6a3ff5007
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
+  YMOverride: b584055b1d78b4556cb313b78c71f16ab4c2b675
+  YMOverrideTestSupport: 5f137d817e6b6d27810a0285014fa2d18fa8f495
 
-PODFILE CHECKSUM: f99d97295040db06bf7edeaf6f0899287e85bee8
+PODFILE CHECKSUM: 495a2ba7eaf053a88228f4d500ace45e59e5cfb3
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/Example-Swift/Override.xcodeproj/project.pbxproj
+++ b/Example-Swift/Override.xcodeproj/project.pbxproj
@@ -367,11 +367,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Override_Example/Pods-Override_Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Override-iOS/Override.framework",
+				"${BUILT_PRODUCTS_DIR}/YMOverride-iOS/YMOverride.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Override.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YMOverride.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -421,11 +421,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Override_Example-TV/Pods-Override_Example-TV-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Override-tvOS/Override.framework",
+				"${BUILT_PRODUCTS_DIR}/YMOverride-tvOS/YMOverride.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Override.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YMOverride.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -439,20 +439,20 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Override_Example-Override_Tests/Pods-Override_Example-Override_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Override-iOS/Override.framework",
+				"${BUILT_PRODUCTS_DIR}/YMOverride-iOS/YMOverride.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
-				"${BUILT_PRODUCTS_DIR}/OverrideTestSupport/OverrideTestSupport.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+				"${BUILT_PRODUCTS_DIR}/YMOverrideTestSupport/YMOverrideTestSupport.framework",
 				"${BUILT_PRODUCTS_DIR}/iOSSnapshotTestCase/FBSnapshotTestCase.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Override.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YMOverride.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OverrideTestSupport.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YMOverrideTestSupport.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example-Swift/Override/AppDelegate.swift
+++ b/Example-Swift/Override/AppDelegate.swift
@@ -2,7 +2,7 @@
 // Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/Override for terms.
 
 import UIKit
-import Override
+import YMOverride
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UITabBarControllerDelegate {

--- a/Example-Swift/Override/MyFeatures.swift
+++ b/Example-Swift/Override/MyFeatures.swift
@@ -2,7 +2,7 @@
 // Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/Override for terms.
 
 import Foundation
-import Override
+import YMOverride
 
 @objc public class ThemeFeatures: FeatureGroup {
     let darkMode = Feature()

--- a/Example-Swift/Override/ViewController.swift
+++ b/Example-Swift/Override/ViewController.swift
@@ -2,7 +2,7 @@
 // Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/Override for terms.
 
 import UIKit
-import Override
+import YMOverride
 
 class ViewController: UIViewController {
 

--- a/Example-Swift/Podfile
+++ b/Example-Swift/Podfile
@@ -4,10 +4,10 @@ use_modular_headers!
 target 'Override_Example' do
   platform :ios, '11.0'
 
-  pod 'Override', :path => '../'
+  pod 'YMOverride', :path => '../'
 
   target 'Override_Tests' do
-    pod 'OverrideTestSupport', :path => '../'
+    pod 'YMOverrideTestSupport', :path => '../'
 
     pod 'Quick', '~>1.3'
     pod 'Nimble', '~>7.1'
@@ -19,5 +19,5 @@ end
 target 'Override_Example-TV' do
   platform :tvos, '11.0'
 
-  pod 'Override', :path => '../'
+  pod 'YMOverride', :path => '../'
 end

--- a/Example-Swift/Podfile.lock
+++ b/Example-Swift/Podfile.lock
@@ -1,30 +1,30 @@
 PODS:
-  - iOSSnapshotTestCase (4.0.1):
-    - iOSSnapshotTestCase/SwiftSupport (= 4.0.1)
-  - iOSSnapshotTestCase/Core (4.0.1)
-  - iOSSnapshotTestCase/SwiftSupport (4.0.1):
+  - iOSSnapshotTestCase (5.0.2):
+    - iOSSnapshotTestCase/SwiftSupport (= 5.0.2)
+  - iOSSnapshotTestCase/Core (5.0.2)
+  - iOSSnapshotTestCase/SwiftSupport (5.0.2):
     - iOSSnapshotTestCase/Core
-  - Nimble (7.3.1)
-  - Nimble-Snapshots (6.9.0):
-    - Nimble-Snapshots/Core (= 6.9.0)
-  - Nimble-Snapshots/Core (6.9.0):
-    - iOSSnapshotTestCase (~> 4.0)
+  - Nimble (7.3.4)
+  - Nimble-Snapshots (6.9.1):
+    - Nimble-Snapshots/Core (= 6.9.1)
+  - Nimble-Snapshots/Core (6.9.1):
+    - iOSSnapshotTestCase (~> 5.0)
     - Nimble (~> 7.0)
-  - Override (2.0.0):
-    - Override/Features (= 2.0.0)
-  - Override/Features (2.0.0)
-  - OverrideTestSupport (2.0.0):
-    - Override (= 2.0.0)
-  - Quick (1.3.2)
-  - SwiftLint (0.29.1)
+  - Quick (1.3.4)
+  - SwiftLint (0.31.0)
+  - YMOverride (2.0.0):
+    - YMOverride/Features (= 2.0.0)
+  - YMOverride/Features (2.0.0)
+  - YMOverrideTestSupport (2.0.0):
+    - YMOverride (= 2.0.0)
 
 DEPENDENCIES:
   - Nimble (~> 7.1)
   - Nimble-Snapshots (~> 6.7)
-  - Override (from `../`)
-  - OverrideTestSupport (from `../`)
   - Quick (~> 1.3)
   - SwiftLint (~> 0.26)
+  - YMOverride (from `../`)
+  - YMOverrideTestSupport (from `../`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -35,20 +35,20 @@ SPEC REPOS:
     - SwiftLint
 
 EXTERNAL SOURCES:
-  Override:
+  YMOverride:
     :path: "../"
-  OverrideTestSupport:
+  YMOverrideTestSupport:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSSnapshotTestCase: f3b2b7e606fe03fdbe49af84316bd235df32dc44
-  Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
-  Nimble-Snapshots: 79394f8d0aea3df54bd5ff78ee9dff05a523a09c
-  Override: b75f1ebb7638c7a42f9879bbbe5876cadfc6b108
-  OverrideTestSupport: 530a5802260e18a58bf5911e48fb5c4cca4919fb
-  Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
-  SwiftLint: 6772320e40b52049053a518c17db9b0634a0b45a
+  iOSSnapshotTestCase: 2d51aa06775e95cecb0a1fb9c5c159ccd1dd4596
+  Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
+  Nimble-Snapshots: bbd1ab264bacc24a9ce24a8363bc05aac783aeb0
+  Quick: f4f7f063c524394c73ed93ac70983c609805d481
+  SwiftLint: 7a0227733d786395817373b2d0ca799fd0093ff3
+  YMOverride: b584055b1d78b4556cb313b78c71f16ab4c2b675
+  YMOverrideTestSupport: 5f137d817e6b6d27810a0285014fa2d18fa8f495
 
-PODFILE CHECKSUM: 93660c687d81d9c2aa2a0d2215d9f730da2f8bea
+PODFILE CHECKSUM: 95a086a62473cf6eb853e6253ebe5b16919ec642
 
 COCOAPODS: 1.6.1

--- a/Example-Swift/Tests/FeatureRegistrySpec.swift
+++ b/Example-Swift/Tests/FeatureRegistrySpec.swift
@@ -3,7 +3,7 @@
 
 import Quick
 import Nimble
-@testable import Override
+@testable import YMOverride
 
 class FeatureRegistrySpec: QuickSpec {
 

--- a/Example-Swift/Tests/FeatureSwitchCellSpec.swift
+++ b/Example-Swift/Tests/FeatureSwitchCellSpec.swift
@@ -1,7 +1,7 @@
 // Copyright 2019, Oath Inc.
 // Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/Override for terms.
 
-@testable import Override
+@testable import YMOverride
 import Quick
 import Nimble
 import Nimble_Snapshots

--- a/Example-Swift/Tests/FeaturesInteractorSpec.swift
+++ b/Example-Swift/Tests/FeaturesInteractorSpec.swift
@@ -4,7 +4,7 @@
 import Foundation
 import Quick
 import Nimble
-@testable import Override
+@testable import YMOverride
 
 fileprivate struct TestLabeledFeatureItem: LabeledFeatureItem {
     let label: String

--- a/Example-Swift/Tests/FeaturesTableViewControllerSpec.swift
+++ b/Example-Swift/Tests/FeaturesTableViewControllerSpec.swift
@@ -4,7 +4,7 @@
 import Quick
 import Nimble
 import Nimble_Snapshots
-@testable import Override
+@testable import YMOverride
 
 class FeaturesTableViewViewControllerSpec: QuickSpec {
 

--- a/Example-Swift/Tests/FeaturesViewControllerSpec.swift
+++ b/Example-Swift/Tests/FeaturesViewControllerSpec.swift
@@ -4,7 +4,7 @@
 import Quick
 import Nimble
 import Nimble_Snapshots
-@testable import Override
+@testable import YMOverride
 
 class FeaturesViewControllerSpec: QuickSpec {
 

--- a/Example-Swift/Tests/OverrideStateSpec.swift
+++ b/Example-Swift/Tests/OverrideStateSpec.swift
@@ -3,8 +3,8 @@
 
 import Quick
 import Nimble
-@testable import Override
-import OverrideTestSupport
+@testable import YMOverride
+import YMOverrideTestSupport
 
 class OverrideStateSpec: QuickSpec {
     override func spec() {

--- a/Example-Swift/Tests/TestHelpersSpec.swift
+++ b/Example-Swift/Tests/TestHelpersSpec.swift
@@ -3,7 +3,7 @@
 
 import Quick
 import Nimble
-import OverrideTestSupport
+import YMOverrideTestSupport
 
 class TestHelpersSpec: QuickSpec {
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Feature flags typically have 3 states: on, off, or defaulted. The default state 
 
 CocoaPods is a dependency manager for Cocoa projects. For usage and installation instructions, [visit their website](https://cocoapods.org). To integrate Override into your Xcode project using CocoaPods, specify it in your Podfile:
 
-`pod 'Override', '~> 1.0'`
+`pod 'YMOverride', '~> 1.0'`
 
 ## Usage
 
@@ -35,6 +35,8 @@ To use Override, you need a subclass of FeatureRegistry. Override will examine y
 Let's create a basic feature called "blueText" which turns all text blue when enabled. To do this, add a property called `blueText` to your feature registry:
 
 ```swift
+import YMOverride
+
 @objc class Features : FeatureRegistry {
 
     @objc let blueText = Feature()
@@ -47,7 +49,7 @@ There is a heck of a lot provided by this simple class, but we'll get into that 
 class ViewController : UIViewController {
 
     let myFeatures = Features()
-    
+
     let label = UILabel()
 
     override func viewWillAppear(_ animated: Bool) {
@@ -56,7 +58,7 @@ class ViewController : UIViewController {
         self.view.addSubview(label)
         label.frame = view.frame
         label.text = "Hello World!"
-        
+
         // Update text color based on feature flag
         label.textColor = myFeatures.blueText ? .blue : .green
     }
@@ -104,7 +106,7 @@ Let's create a feature that is normally off, and turned on only for debugging:
 @objc class Features : FeatureRegistry {
 
     @objc let blueText = Feature()
-    
+
     @obj let debugLogging = Feature(defaultState: false)
 }
 ```
@@ -117,9 +119,9 @@ It would be fantastic if all of our feature flags took effect immediately. In re
 @objc class Features : FeatureRegistry {
 
     @objc let blueText = Feature()
-    
+
     @obj let debugLogging = Feature(defaultState: false)
-    
+
     @objc let useTabBarNav = Feature(requiresRestart: true) 
 }
 ```
@@ -134,11 +136,11 @@ Sometimes, there is a need for a feature which defaults to on or off depending o
 @objc class Features : FeatureRegistry {
 
     @objc let blueText = Feature()
-    
+
     @obj let debugLogging = Feature(defaultState: false)
-    
+
     @objc let useTabBarNav = Feature(requiresRestart: true) 
-    
+
     @objc let tuesdayExperiment = DynamicFeature() { _ in
         let components = Calendar.current.dateComponents(Set([.weekday]), from: Date())
         return components.weekday == 3
@@ -158,7 +160,7 @@ As an exercise, let's see what it would look like to create an Override wrapper 
 @objc class FConfigFeature : DynamicFeature {
 
     init(key: String? = nil, requiresRestart: Bool = false, configDefault: Bool = false) {
-    
+
         // Delegate to FConfig, using the provided default parameter as FConfig default.
         super.init(key: key, requiresRestart: requiresRestart) { (feature: AnyFeature) -> Bool in
             return FConfig.sharedInstance.getBool(forKey: feature.key, withDefault: configDefault)
@@ -173,16 +175,16 @@ Now using `FConfigFeature` in our feature registry is just more of the same:
 @objc class Features : FeatureRegistry {
 
     @objc let blueText = Feature()
-    
+
     @obj let debugLogging = Feature(defaultState: false)
-    
+
     @objc let useTabBarNav = Feature(requiresRestart: true) 
-    
+
     @objc let tuesdayExperiment = DynamicFeature() { _ in
         let components = Calendar.current.dateComponents(Set([.weekday]), from: Date())
         return components.weekday == 3
     }
-    
+
     // FConfig backed feature
     @objc let redButtons = FConfigFeature()
 }
@@ -242,7 +244,7 @@ describe("sans serif font experiment") {
             // test or snapshot test for enabled state
         }
     }
-        
+
     it("respects the enabled flag") {
         withFeature(features.useSansSerifFont).disabled {
             // test or snapshot test for disabled state

--- a/Source/TestSupport/FeatureTestSupport.swift
+++ b/Source/TestSupport/FeatureTestSupport.swift
@@ -2,7 +2,7 @@
 // Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/Override for terms.
 
 import Foundation
-import Override
+import YMOverride
 
 @objc public class FeatureTestSupport: NSObject {
 

--- a/YMOverride.podspec
+++ b/YMOverride.podspec
@@ -7,9 +7,9 @@
 #
 
 Pod::Spec.new do |s|
-    s.name             = 'Override'
+    s.name             = 'YMOverride'
     s.version          = '2.0.0'
-    s.summary          = 'In-app feature management'
+    s.summary          = 'Simple Swift Feature Flag Managment, From Yahoo'
     s.description      = <<-DESC
     Override helps minimize the boilerplate involved with adding and maintaining feature flags.
     Typically app developers employ feature flags to manage access to feature which are still in

--- a/YMOverrideTestSupport.podspec
+++ b/YMOverrideTestSupport.podspec
@@ -7,9 +7,9 @@
 #
 
 Pod::Spec.new do |s|
-    s.name             = 'OverrideTestSupport'
+    s.name             = 'YMOverrideTestSupport'
     s.version          = '2.0.0'
-    s.summary          = 'Test support helpers for Override feature management pod'
+    s.summary          = 'Test support helpers for YMOverride feature management'
     s.description      = <<-DESC
     This pod provides test support facilities for the Override pod.
     DESC
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
     s.source_files = 'Source/TestSupport/*.{swift,h}'
 
     # Require the version of OverrideTestSupport to match the version of Override
-    s.dependency 'Override', '=' + s.version.to_s
+    s.dependency 'YMOverride', '=' + s.version.to_s
 end


### PR DESCRIPTION
## Description
Adds YM prefix to the pod, for YMOverride

## Motivation and Context
There is a conflict with the pod name "Override", so adding YM for Yahoo Mobile

## How Has This Been Tested?
Yes. Tests pass.

## Screenshots (if appropriate):
NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.