### PR TITLE
[Bug] Nested FeatureGroup objects are not configured

### DIFF
--- a/Source/FeatureRegistry.swift
+++ b/Source/FeatureRegistry.swift
@@ -125,8 +125,11 @@ extension LabeledGroupItem { /* Collection Support */
 
     private func configure(groupItem: LabeledGroupItem) {
         groupItem.forEach { item in
-            guard let featureItem = item as? LabeledFeatureItem else { return }
-            configure(featureItem: featureItem)
+            if let featureItem = item as? LabeledFeatureItem {
+                configure(featureItem: featureItem)
+            } else if let groupItem = item as? LabeledGroupItem {
+                configure(groupItem: groupItem)
+            }
         }
     }
 }

--- a/YMOverride.podspec
+++ b/YMOverride.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverride'
-    s.version          = '2.2.0'
+    s.version          = '2.3.0'
     s.summary          = 'Simple Swift Feature Flag Managment, From Yahoo'
     s.description      = <<-DESC
     Override helps minimize the boilerplate involved with adding and maintaining feature flags.

--- a/YMOverrideTestSupport.podspec
+++ b/YMOverrideTestSupport.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverrideTestSupport'
-    s.version          = '2.2.0'
+    s.version          = '2.3.0'
     s.summary          = 'Test support helpers for YMOverride feature management'
     s.description      = <<-DESC
     This pod provides test support facilities for the Override pod.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes a bug that caused nested FeatureGroup objects to be ignored during configuration so their values aren't set correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was tested by running the example app, making changes to a feature in a nested FeatureGroup, exiting the app and confirming that the changes were applied correctly on the next app launch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
