### PR TITLE
Add group feature titles to debug enabled feature method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 2.2.0
-- Add function for retrieving currently enabled featured  
+- Add function for retrieving currently enabled features as an array of String objects
   
 ## 2.1.1
   - Bug Fixes

--- a/Example-Swift/Tests/FeatureRegistrySpec.swift
+++ b/Example-Swift/Tests/FeatureRegistrySpec.swift
@@ -213,23 +213,23 @@ class FeatureRegistrySpec: QuickSpec {
                     public let groupFeature1 = Feature()
                     public let groupFeature2 = Feature(requiresRestart: false, defaultState: true)
                     public let groupFeature3 = Feature()
-                    public let nestedGroup1 = TestNestedFeatureGroup()
+                    public let nestedGroup = TestNestedFeatureGroup()
                 }
 
                 public let feature1 = Feature(requiresRestart: false, defaultState: true)
                 public let feature2 = Feature()
                 public let feature3 = Feature()
                 public let feature4 = Feature()
-                public let groupFeature1 = TestFeatureGroup()
+                public let groupFeature = TestFeatureGroup()
             }
 
             let registry = TestRegistry(withFeatureStore: nil)
             registry.feature3.override = .enabled
             let enabledFeatureNames = TestRegistry.enabledFeatures(in: registry)
-            expect(enabledFeatureNames).to(equal([ "feature1",
-                                                   "feature3",
-                                                   "groupFeature2",
-                                                   "nestedGroupFeature2" ]))
+            expect(enabledFeatureNames).to(equal([ "Feature1",
+                                                   "Feature3",
+                                                   "Group Feature → Group Feature2",
+                                                   "Group Feature → Nested Group → Nested Group Feature2" ]))
         }
 
     }

--- a/Source/FeatureRegistry.swift
+++ b/Source/FeatureRegistry.swift
@@ -152,7 +152,7 @@ internal extension Collection where Element == LabeledItem {
         return self.flatMap { labeledItem -> [T] in
             switch labeledItem {
             case let featureGroup as LabeledGroupItem:
-                // Traverse into the group and add the group the nextGroupItems
+                // Traverse into the group and add the group to nextGroupItems
                 var nextGroupItems = groupItems
                 nextGroupItems.append(featureGroup)
                 return featureGroup.depthFirstMap(groupItems: nextGroupItems, resultBuilder: resultBuilder, filter: filter)

--- a/Source/FeatureRegistry.swift
+++ b/Source/FeatureRegistry.swift
@@ -202,7 +202,9 @@ internal extension Collection where Element == LabeledItem {
 
 extension FeatureRegistry {
 
-    /// Returns the label values for the enabled features in the provided registry.
+    /// Returns the names for the enabled features in the provided registry.
+    /// If a feature is embedded in a Freature Group, the group name is prepended
+    /// and formatted like: "feature_group → feature_name"
     /// Primarily used for debugging.
     /// - Parameter featureRegistry: The feature registry that should be used to find enabled features
     @objc public static func enabledFeatures(in featureRegistry: FeatureRegistry) -> [String] {

--- a/Source/FeatureRegistry.swift
+++ b/Source/FeatureRegistry.swift
@@ -145,7 +145,7 @@ internal extension Collection where Element == LabeledItem {
     ///   - groupItems: Array of `LabelGroupItems` types that keeps track of the parent group items of a feature.
     ///   - resultBuilder: Configuration block for creating the return type at the end of the tree
     ///   - filter: Includes the element if the given predicate is satisfied
-    func depthFirstMap<T>(groupItems: [LabeledGroupItem] = [],
+    func depthFirstCompactMap<T>(groupItems: [LabeledGroupItem] = [],
         resultBuilder:(([LabeledGroupItem], LabeledFeatureItem) -> T),
         filter: ((LabeledFeatureItem) -> Bool) = {_ in true }) -> [T] {
 
@@ -155,7 +155,7 @@ internal extension Collection where Element == LabeledItem {
                 // Traverse into the group and add the group to nextGroupItems
                 var nextGroupItems = groupItems
                 nextGroupItems.append(featureGroup)
-                return featureGroup.depthFirstMap(groupItems: nextGroupItems, resultBuilder: resultBuilder, filter: filter)
+                return featureGroup.depthFirstCompactMap(groupItems: nextGroupItems, resultBuilder: resultBuilder, filter: filter)
             case let feature as LabeledFeatureItem where filter(feature):
                 // For single items, use the result builder to create the required type
                 return [resultBuilder(groupItems, feature)]
@@ -209,7 +209,7 @@ extension FeatureRegistry {
     /// - Parameter featureRegistry: The feature registry that should be used to find enabled features
     @objc public static func enabledFeatures(in featureRegistry: FeatureRegistry) -> [String] {
 
-        return featureRegistry.features.depthFirstMap( resultBuilder: { (groupStack, feature) -> String in
+        return featureRegistry.features.depthFirstCompactMap( resultBuilder: { (groupStack, feature) -> String in
             let mergedString = groupStack.map { $0.label.unCamelCased }.joined(separator: " → ")
             return mergedString.isEmpty ? feature.label.unCamelCased : mergedString + " → \(feature.label.unCamelCased)"
         }) { (featureItem) -> Bool in

--- a/Source/UI/FeaturesPresenter.swift
+++ b/Source/UI/FeaturesPresenter.swift
@@ -107,7 +107,7 @@ extension FeaturesPresenter { /* UITableViewController Support Methods */
             return
         }
 
-        filteredFeatures = allFeatures.depthFirstMap(resultBuilder: { groupStack, feature in
+        filteredFeatures = allFeatures.depthFirstCompactMap(resultBuilder: { groupStack, feature in
                                                 return LabeledSearchResultItem(groupStack: groupStack, result: feature)
                                             },
                                             filter: { feature in

--- a/Source/UI/FeaturesPresenter.swift
+++ b/Source/UI/FeaturesPresenter.swift
@@ -101,34 +101,18 @@ extension FeaturesPresenter { /* UITableViewController Support Methods */
         let result: LabeledFeatureItem
     }
 
-    private func depthFirstFilter<T: Collection>(features: T, searchPath: [LabeledGroupItem], query: String) -> [LabeledSearchResultItem] where T.Element == LabeledItem {
-        return features.flatMap { labeledItem -> [LabeledSearchResultItem] in
-            switch labeledItem {
-            case let featureGroup as LabeledGroupItem:
-                // Traverse into the group, but to not match on the group item itself
-                var nextSearchPath = searchPath
-                nextSearchPath.append(featureGroup)
-                return depthFirstFilter(features: featureGroup, searchPath: nextSearchPath, query: query)
-
-            case let feature as LabeledFeatureItem where feature.label.lowercased().contains(query):
-                // For single items, return if they are a match
-                return [LabeledSearchResultItem(groupStack: searchPath, result: feature)]
-
-            default:
-                // For any custom subclass which we don't know about, bail.
-                return [LabeledSearchResultItem]()
-            }
-        }
-    }
-
     func filter(_ tableView: UITableView, query: String?) {
         guard let query = query?.lowercased() else {
             filteredFeatures = nil
             return
         }
 
-        filteredFeatures = depthFirstFilter(features: allFeatures, searchPath: [LabeledGroupItem](), query: query)
-
+        filteredFeatures = allFeatures.depthFirstMap(resultBuilder: { groupStack, feature in
+                                                return LabeledSearchResultItem(groupStack: groupStack, result: feature)
+                                            },
+                                            filter: { feature in
+                                                return feature.label.lowercased().contains(query)
+                                            })
         tableView.reloadData()
     }
 

--- a/YMOverride.podspec
+++ b/YMOverride.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverride'
-    s.version          = '2.3.0'
+    s.version          = '2.2.0'
     s.summary          = 'Simple Swift Feature Flag Managment, From Yahoo'
     s.description      = <<-DESC
     Override helps minimize the boilerplate involved with adding and maintaining feature flags.

--- a/YMOverrideTestSupport.podspec
+++ b/YMOverrideTestSupport.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverrideTestSupport'
-    s.version          = '2.4.0'
+    s.version          = '2.2.0'
     s.summary          = 'Test support helpers for YMOverride feature management'
     s.description      = <<-DESC
     This pod provides test support facilities for the Override pod.

--- a/YMOverrideTestSupport.podspec
+++ b/YMOverrideTestSupport.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverrideTestSupport'
-    s.version          = '2.3.0'
+    s.version          = '2.4.0'
     s.summary          = 'Test support helpers for YMOverride feature management'
     s.description      = <<-DESC
     This pod provides test support facilities for the Override pod.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a followup to the changes made in PR #13 

Because Features can be nested in any number of Feature Groups, naming doesn't have to be unique or very descriptive. For example, it would be perfectly acceptable for a "Home Tab" feature group and a "Settings Tab" feature group to both have a "Dark Mode" feature. If only one is enabled, the current implementation wouldn't be able to indicate which of the "Dark Mode" features are enabled, only that one of them are. 

To address this, the function now appends the feature name to its parent feature group(s), giving proper context to the feature name. Using the same example as above, the enabled feature would now be returned as "Home Tab -> Dark Mode".

The recursive function that I used for this was very similar to the one that was used for the parsing the search path in the search feature so I used that as template and created a function that would work for both and potentially many feature use cases.

Marking this as a "Breaking Feature" because it changes the way the `enabledFeatures` function formats its strings. If someone was already using it, the strings would look different. Considering how new this feature is, I think its better than deprecating and creating a new function to keep backwards compatibility.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See description above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
