### PR TITLE
Fix for non-responsive navigationItem in FeaturesTableViewController iOS 13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 2.3.1
+- Fixes non-responsive share button issue that arose due to overriding navigationItem in the release of iOS 13.4
+
 ## 2.3.0
 - Ability to copy a readable string with a list of all displayed features, enabled, disabled or overriden features!
 - Share button added to the UI

--- a/Source/UI/FeaturesTableViewController.swift
+++ b/Source/UI/FeaturesTableViewController.swift
@@ -42,6 +42,7 @@ import UIKit
         #if os(iOS)
         extendedViewDidLoad()
         #endif
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share))
     }
 }
 
@@ -74,12 +75,6 @@ extension FeaturesTableViewController {
         } else {
             tableView.tableHeaderView = searchController.searchBar
         }
-    }
-
-    public override var navigationItem: UINavigationItem {
-        let rightItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share))
-        super.navigationItem.rightBarButtonItem = rightItem
-        return super.navigationItem
     }
 
     @objc func share(sender: UIBarButtonItem) {

--- a/YMOverride.podspec
+++ b/YMOverride.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverride'
-    s.version          = '2.3.0'
+    s.version          = '2.3.1'
     s.summary          = 'Simple Swift Feature Flag Managment, From Yahoo'
     s.description      = <<-DESC
     Override helps minimize the boilerplate involved with adding and maintaining feature flags.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an issue where the `navigationItem.rightBarButtonItem` is non-responsive on devices running iOS 13.4. After apple released 13.4, issues with overriding `navigationItem` surfaced. Setting properties on the existing `navigationItem` rather than overriding it resolves this issue.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/yahoo/Override/issues/22

This is required to fix the non-responsive `navigationItem.rightBarButtonItem`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've ran the sample app and tested the share button to ensure that with these changes the button is responsive on devices running iOS 13.4

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
