### PR TITLE
Fix for Assertion when built with the iOS15 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 2.4.0
+- Added a new convenience init that accepts a FeatureRegistry to FeaturesTableViewController to work around an assertion in UITableViewController
+
 ## 2.3.1
 - Fixes non-responsive share button issue that arose due to overriding navigationItem in the release of iOS 13.4
 

--- a/Source/UI/FeaturesTableViewController.swift
+++ b/Source/UI/FeaturesTableViewController.swift
@@ -96,3 +96,15 @@ extension FeaturesTableViewController {
         self.init(features: featureRegistry.features)
     }
 }
+
+public extension FeaturesTableViewController {
+
+    /// Initialize using a FeatureRegistry directly. This initializer
+    /// allows use of this table view controller without the navigation
+    /// controller provided by FeaturesViewController.
+    ///
+    /// - Parameter featureRegistry: The feature registry to use
+    convenience init(registry: FeatureRegistry) {
+        self.init(features: registry.features)
+    }
+}

--- a/YMOverride.podspec
+++ b/YMOverride.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverride'
-    s.version          = '2.3.1'
+    s.version          = '2.4.0'
     s.summary          = 'Simple Swift Feature Flag Managment, From Yahoo'
     s.description      = <<-DESC
     Override helps minimize the boilerplate involved with adding and maintaining feature flags.


### PR DESCRIPTION
## Description
This adds a new convenience init that takes `FeatureRegistry` as a parameter to `FeaturesTableViewController` to avoid an exception that occurs when using the iOS 15 SDK. The existing init with `FeatureRegistry` causes a crash when built with the iOS 15 SDK. If you remove the `@objc` the crash is eliminated.

## Motivation and Context
This is a fix for a new crash that occurs when building with the iOS15 SDK.

### Crash details
 *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UIViewController is missing its initial trait collection populated during initialization. This is a serious bug, likely caused by accessing properties or methods on the view controller before calling a UIViewController initializer. View controller: <UITableViewController: 0x7fcbe2c288b0>'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000122b61bb4 __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x000000011a75abe7 objc_exception_throw + 48
	2   Foundation                          0x000000011c317da9 -[NSMutableDictionary(NSMutableDictionary) classForCoder] + 0
	3   UIKitCore                           0x000000013d0f56c6 UIViewControllerMissingInitialTraitCollection + 188
	4   UIKitCore                           0x000000013d0f9bef -[UIViewController traitCollection] + 155
	5   UIKitCore                           0x000000013d0e893a -[UITableViewController dealloc] + 196
	6   Y! Finance                          0x000000011151545f $s10YMOverride27FeaturesTableViewControllerC15featureRegistryAcA07FeatureG0C_tcfc + 239
	7   Y! Finance                          0x00000001115154a8 $s10YMOverride27FeaturesTableViewControllerC15featureRegistryAcA07FeatureG0C_tcfcTo + 40
	8   Y! Finance                          0x000000011151534f $s10YMOverride27FeaturesTableViewControllerC15featureRegistryAcA07FeatureG0C_tcfC + 47
	9   Y! Finance                          0x000000010efee00e $s10Y__Finance22SettingsViewControllerC23handleChildItemSelected05childG0yAA0bfG0O_tF + 974
	10  Y! Finance                          0x000000010efed409 $s10Y__Finance22SettingsViewControllerC010collectionC0_15didSelectItemAtySo012UICollectionC0C_10Foundation9IndexPathVtF + 761
	11  Y! Finance                          0x000000010efee2b1 $s10Y__Finance22SettingsViewControllerC010collectionC0_15didSelectItemAtySo012UICollectionC0C_10Foundation9IndexPathVtFTo + 129
	12  UIKitCore                           0x000000013cefd019 -[UICollectionView _selectItemAtIndexPath:animated:scrollPosition:notifyDelegate:deselectPrevious:performCustomSelectionAction:] + 941
	13  UIKitCore                           0x000000013cf3082a -[UICollectionView _userSelectItemAtIndexPath:] + 194
	14  UIKitCore                           0x000000013cf30ac9 -[UICollectionView touchesEnded:withEvent:] + 656
	15  UIKitCore                           0x000000013d8ebc7f forwardTouchMethod + 321
	16  UIKitCore                           0x000000013d8ebc7f forwardTouchMethod + 321
	17  UIKitCore                           0x000000013d384b5a _UIGestureEnvironmentUpdate + 9184
	18  UIKitCore                           0x000000013d3822f2 -[UIGestureEnvironment _updateForEvent:window:] + 902
	19  UIKitCore                           0x000000013d8fe9c9 -[UIWindow sendEvent:] + 5273
	20  UIKitCore                           0x000000013d8d54e8 -[UIApplication sendEvent:] + 825
	21  UIKitCore                           0x000000013d96b28a __dispatchPreprocessedEventFromEventQueue + 8695
	22  UIKitCore                           0x000000013d96da10 __processEventQueue + 8579
	23  UIKitCore                           0x000000013d9641b6 __eventFetcherSourceCallback + 240
	24  CoreFoundation                      0x0000000122acfe25 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
	25  CoreFoundation                      0x0000000122acfd1d __CFRunLoopDoSource0 + 180
	26  CoreFoundation                      0x0000000122acf1f2 __CFRunLoopDoSources0 + 242
	27  CoreFoundation                      0x0000000122ac9951 __CFRunLoopRun + 875
	28  CoreFoundation                      0x0000000122ac9103 CFRunLoopRunSpecific + 567
	29  GraphicsServices                    0x000000012b1c8cd3 GSEventRunModal + 139
	30  UIKitCore                           0x000000013d8b5e63 -[UIApplication _run] + 928
	31  UIKitCore                           0x000000013d8baa53 UIApplicationMain + 101
	32  Y! Finance                          0x000000010ea9a9f7 main + 183
	33  dyld                                0x0000000119e48e1e start_sim + 10
	34  ???                                 0x0000000000000001 0x0 + 1

## How Has This Been Tested?
I was unable to use the Example-Swift tests or Example-ObjC tests due to a problem with the test targets.  The demo apps do build and run.  I did in app integration testing.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
