### PR TITLE
Add SwiftPM and Github actions support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,89 @@
+name: "YMOverride CI"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  ExampleObjC:
+    name: ObjC Example Project (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod install
+        run: pod install --project-directory=Example-ObjC
+
+      - name: Build Project
+        uses: sersoft-gmbh/xcodebuild-action@v1.8.0
+        with:
+          workspace: Example-ObjC/Example-ObjC.xcworkspace
+          scheme: Example-ObjC
+          destination: name=iPhone 13 Pro
+          action: test
+
+  ExampleSwift:
+    name: Swift Example Project (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod install
+        run: pod install --project-directory=Example-Swift
+
+      - name: Build Project
+        uses: sersoft-gmbh/xcodebuild-action@v1.8.0
+        with:
+          workspace: Example-Swift/Override.xcworkspace
+          scheme: Override-Example
+          destination: name=iPhone 13 Pro
+          action: build # TODO: Fix Nimble library issues with tests.
+          
+  Pods:
+    name: Cocoapods Lint (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod lib lint dynamic-framework
+        run: pod lib lint --fail-fast --include-podspecs=YMOverride.podspec
+
+      - name: Run pod lib lint static-framework
+        run: pod lib lint --fail-fast --use-libraries --use-modular-headers --include-podspecs=YMOverride.podspec
+          
+  SwiftPM:
+    name: SwiftPM (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable 
+
+      - name: Build
+        run: xcodebuild -scheme YMOverride -destination generic/platform=iOS

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ Carthage/Build
 Pods/
 vendor/
 test_output/
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/Example-ObjC/Example-ObjC.xcodeproj/project.pbxproj
+++ b/Example-ObjC/Example-ObjC.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		FC321D5A20DF5D5D000EE23D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FC321D5920DF5D5D000EE23D /* Assets.xcassets */; };
 		FC321D5D20DF5D5D000EE23D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FC321D5B20DF5D5D000EE23D /* LaunchScreen.storyboard */; };
 		FC321D6020DF5D5D000EE23D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FC321D5F20DF5D5D000EE23D /* main.m */; };
-		FC321D6A20DF6035000EE23D /* Override.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC321D6920DF6035000EE23D /* Override.framework */; };
 		FC321D6D20DF6E4E000EE23D /* MyFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC321D6C20DF6E4E000EE23D /* MyFeatures.swift */; };
 /* End PBXBuildFile section */
 
@@ -69,7 +68,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				32CC128A52909BAD1A324AE4 /* Pods_Example_ObjC.framework in Frameworks */,
-				FC321D6A20DF6035000EE23D /* Override.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example-ObjC/Example-ObjC/Base.lproj/Main.storyboard
+++ b/Example-ObjC/Example-ObjC/Base.lproj/Main.storyboard
@@ -49,7 +49,7 @@
         <!--Second-->
         <scene sceneID="Vzj-rn-biB">
             <objects>
-                <tableViewController id="0R8-Pv-1PA" customClass="FeaturesViewController" customModule="Override" sceneMemberID="viewController">
+                <tableViewController id="0R8-Pv-1PA" customClass="FeaturesViewController" customModule="YMOverride" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="DYy-xL-yBR">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Example-ObjC/Example-ObjCTests/FeatureTestSupportSpec.m
+++ b/Example-ObjC/Example-ObjCTests/FeatureTestSupportSpec.m
@@ -5,8 +5,7 @@
 
 #import <Expecta/Expecta.h>
 #import <Specta/Specta.h>
-#import <YMOverrideTestSupport/OverrideTestSupport-Swift.h>
-#import <YMOverrideTestSupport/FeatureTestSupport.h>
+@import YMOverrideTestSupport;
 
 SpecBegin(FeatureTestSupport)
 describe(@"Feature Test Support", ^{

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "YMOverride",
+    platforms: [
+        .iOS(.v10),
+        .tvOS(.v10),
+    ],
+    products: [
+        .library(
+            name: "YMOverride",
+            targets: ["YMOverride"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "YMOverride",
+            path: "Source",
+            exclude: [
+                "TestSupport"
+            ]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Override
 
+[![CI Status](https://github.com/yahoo/Override/workflows/YMOverride%20CI/badge.svg?branch=master)](https://github.com/yahoo/Override/actions)
+
 ## Table of Contents
 
 - [Background](#background)
@@ -25,6 +27,10 @@ Feature flags typically have 3 states: on, off, or defaulted. The default state 
 CocoaPods is a dependency manager for Cocoa projects. For usage and installation instructions, [visit their website](https://cocoapods.org). To integrate Override into your Xcode project using CocoaPods, specify it in your Podfile:
 
 `pod 'YMOverride', '~> 2.2'`
+
+### SwiftPM
+
+Add `.package(url: "https://github.com/yahoo/Override.git", from: "2.4.0")` to your `package.swift`
 
 ## Usage
 

--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example-Swift/Pods/Pods.xcodeproj


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add a SwiftPM manifest file
* Update the .gitignore file to ignore local Swiftpm artifacts
* Add Github actions for continuous integration. Actions will take into affect immediately as shown on my fork: https://github.com/master-nevi/Override/actions
* Update README badge
* Removed the `_Pods.xcodeproj` symlink as it doesn't appear to be used. I can add it back but I believe it's an artifact of the original [`pod lib create`](https://guides.cocoapods.org/making/using-pod-lib-create) for Carthage support which isn't referenced in the README.

NOTE: There appears to be some build issue with Nimble in the `Example-Swift` project and so the CI builds but is currently unable to run tests. Support from original maintainers of the library would be needed for this.

## How Has This Been Tested?
With test tools described in the Github actions yaml file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
