### PR TITLE
Add Test Support to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,9 @@ let package = Package(
         .library(
             name: "YMOverride",
             targets: ["YMOverride"]),
+        .library(
+            name: "YMOverrideTestSupport",
+            targets: ["YMOverrideTestSupport"]),
     ],
     dependencies: [],
     targets: [
@@ -21,5 +24,11 @@ let package = Package(
             exclude: [
                 "TestSupport"
             ]),
+        .target(
+            name: "YMOverrideTestSupport",
+            dependencies: [
+                "YMOverride"
+            ],
+            path: "Source/TestSupport"),
     ]
 )


### PR DESCRIPTION
## Description
This adds Test Support library.
This only works for Swift.  The Obj-C support is via the macros in FeatureTestSupport.h which I am guessing requires another target, but I am not sure how this should work since there is no actual Obj-C code.

## Motivation and Context
We use the Test Support a lot in our tests and not having this was preventing us from migrating to SPM.  

## How Has This Been Tested?
I can now build tests that make use of `withFeature`/`withFeatures`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
