### PR TITLE
Bump version to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+### 2.6.0
+- Add YMOverrideTestSupport package to SPM
+
 ## 2.5.0
 - Add support for Swift Package Manager (SPM)
 

--- a/YMOverride.podspec
+++ b/YMOverride.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverride'
-    s.version          = '2.5.0'
+    s.version          = '2.6.0'
     s.summary          = 'Simple Swift Feature Flag Managment, From Yahoo'
     s.description      = <<-DESC
     Override helps minimize the boilerplate involved with adding and maintaining feature flags.

--- a/YMOverrideTestSupport.podspec
+++ b/YMOverrideTestSupport.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'YMOverrideTestSupport'
-    s.version          = '2.5.0'
+    s.version          = '2.6.0'
     s.summary          = 'Test support helpers for YMOverride feature management'
     s.description      = <<-DESC
     This pod provides test support facilities for the Override pod.


### PR DESCRIPTION
## Description

While SPM support was added back in #32, it did not include a definition
for the YMOverrideTestSupport library. This is pretty useful for those
who like to add tests around the state of feature flags.

@cshaines updated the SPM manifest in #40, but we never published a new
release. Bump the version to 2.6.0, then we can tag and publish to both
CocoaPods and SPM.

## How Has This Been Tested?

This has been in use via a fork (https://github.com/cshaines/Override/) for
a while and was contributed back to this repo in #40. Just need to bump
the versions and publish it.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
