### PR TITLE
Add Customizable Color Provider for Feature State Colors

### DIFF
--- a/Example-Swift/Tests/FeaturesInteractorSpec.swift
+++ b/Example-Swift/Tests/FeaturesInteractorSpec.swift
@@ -38,7 +38,8 @@ class FeatureInteractorSpec: QuickSpec {
         describe("Feature Registry") {
 
             it("Initializes properly") {
-                let presenter = FeaturesPresenter(withFeatures: [])
+                let presenter = FeaturesPresenter(withFeatures: [],
+                                                  colorProvider: DefaultFeatureStateColorProvider())
                 let interactor = FeaturesInteractor(withPresenter: presenter)
 
                 expect(interactor).to(be(interactor))
@@ -48,7 +49,8 @@ class FeatureInteractorSpec: QuickSpec {
                 let registry = TestRegistry(withFeatureStore: nil)
 
                 context("shouldHighlightRowAt") {
-                    let presenter = FeaturesPresenter(withFeatures:  registry.featureItems)
+                    let presenter = FeaturesPresenter(withFeatures:  registry.featureItems,
+                                                      colorProvider: DefaultFeatureStateColorProvider())
                     let interactor = FeaturesInteractor(withPresenter: presenter)
 
                     it("false for cells") {
@@ -70,7 +72,8 @@ class FeatureInteractorSpec: QuickSpec {
                     var output: UIViewController!
 
                     beforeEach {
-                        presenter = FeaturesPresenter(withFeatures:  registry.featureItems)
+                        presenter = FeaturesPresenter(withFeatures:  registry.featureItems,
+                                                      colorProvider: DefaultFeatureStateColorProvider())
                         interactor = FeaturesInteractor(withPresenter: presenter)
                         testTableView = TestTableView(frame: .zero, style: .plain)
                     }
@@ -137,7 +140,8 @@ class FeatureInteractorIosSpec: QuickSpec {
             let registry = TestRegistry(withFeatureStore: nil)
             var features = registry.featureItems
             features.append(CustomFeature())
-            let presenter = FeaturesPresenter(withFeatures: features)
+            let presenter = FeaturesPresenter(withFeatures: features,
+                                              colorProvider: DefaultFeatureStateColorProvider())
             let interactor = FeaturesInteractor(withPresenter: presenter)
 
             it("does not configure swipe for groups") {

--- a/Source/UI/Cells/FeatureSwitchCell.swift
+++ b/Source/UI/Cells/FeatureSwitchCell.swift
@@ -15,33 +15,7 @@ class FeatureSwitchCell: FeatureTableViewCell {
     let underlineStyleSingle = NSUnderlineStyle.styleSingle
     #endif
 
-    var labeledFeature: LabeledFeatureItem? {
-        didSet {
-            guard let feature = labeledFeature?.feature,
-                let label = labeledFeature?.label,
-                let textLabel = textLabel
-                else { return }
-
-            let labelColor = feature.enabled ? UIColor.mulah : UIColor.swedishFish
-
-            let labelString = NSMutableAttributedString(string: label.unCamelCased)
-            var attrs: [AttributedStringKey: Any] = [
-                AttributedStringKey.font: textLabel.font as UIFont,
-                AttributedStringKey.foregroundColor: labelColor
-            ]
-
-            // add emphasis if this is locally overridden by underlining the label
-            if feature.override != .featureDefault {
-                attrs[AttributedStringKey.underlineStyle] = underlineStyleSingle.rawValue
-                attrs[AttributedStringKey.underlineColor] = labelColor
-            }
-            labelString.addAttributes(attrs, range: NSRange(location: 0, length: labelString.length))
-
-            textLabel.attributedText = labelString
-
-            self.setNeedsLayout()
-        }
-    }
+    private var labeledFeature: LabeledFeatureItem?
 
     var featurePath: [LabeledGroupItem]? {
         didSet {
@@ -77,5 +51,33 @@ class FeatureSwitchCell: FeatureTableViewCell {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with labeledFeature: LabeledFeatureItem?,
+                   colorProvider: FeatureStateColorProvider) {
+        guard let feature = labeledFeature?.feature,
+              let label = labeledFeature?.label,
+              let textLabel = textLabel
+        else { return }
+
+        let colors = colorProvider.colors(for: feature)
+        let labelColor = feature.enabled ? colors.enabledColor : colors.disabledColor
+
+        let labelString = NSMutableAttributedString(string: label.unCamelCased)
+        var attrs: [AttributedStringKey: Any] = [
+            AttributedStringKey.font: textLabel.font as UIFont,
+            AttributedStringKey.foregroundColor: labelColor
+        ]
+
+        // add emphasis if this is locally overridden by underlining the label
+        if feature.override != .featureDefault {
+            attrs[AttributedStringKey.underlineStyle] = underlineStyleSingle.rawValue
+            attrs[AttributedStringKey.underlineColor] = labelColor
+        }
+        labelString.addAttributes(attrs, range: NSRange(location: 0, length: labelString.length))
+
+        textLabel.attributedText = labelString
+
+        self.setNeedsLayout()
     }
 }

--- a/Source/UI/FeatureStateColorProvider.swift
+++ b/Source/UI/FeatureStateColorProvider.swift
@@ -1,0 +1,56 @@
+// Copyright 2019, Oath Inc.
+// Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/Override for terms.
+
+import Foundation
+import UIKit
+
+/// A container for feature state colors
+@objc public class FeatureStateColors: NSObject {
+    @objc public let enabledColor: UIColor
+    @objc public let disabledColor: UIColor
+
+    @objc public init(enabledColor: UIColor, disabledColor: UIColor) {
+        self.enabledColor = enabledColor
+        self.disabledColor = disabledColor
+        super.init()
+    }
+
+    @objc public static let defaultStateColors: FeatureStateColors = {
+        FeatureStateColors(enabledColor: .mulah, disabledColor: .swedishFish)
+    }()
+}
+
+/// A protocol for providing colors based on feature state.
+/// Implement this protocol to customize colors for enabled and disabled feature states.
+@objc public protocol FeatureStateColorProvider: NSObjectProtocol {
+    /// Returns the colors to use for a given feature's enabled and disabled states.
+    ///
+    /// - Parameter feature: The feature to resolve colors for
+    /// - Returns: A FeatureStateColors object containing the enabled color and disabled color
+    func colors(for feature: AnyFeature) -> FeatureStateColors
+}
+
+/// Default implementation that uses the standard mulah (green) and swedishFish (red) colors.
+@objc public class DefaultFeatureStateColorProvider: NSObject, FeatureStateColorProvider {
+    @objc public override init() {
+        super.init()
+    }
+    
+    @objc public func colors(for feature: AnyFeature) -> FeatureStateColors {
+        FeatureStateColors.defaultStateColors
+    }
+}
+
+/// Adapter that allows using a closure as a FeatureStateColorProvider
+public class ClosureFeatureStateColorProvider: NSObject, FeatureStateColorProvider {
+    private let resolver: (AnyFeature) -> FeatureStateColors
+
+    public init(_ resolver: @escaping (AnyFeature) -> FeatureStateColors) {
+        self.resolver = resolver
+        super.init()
+    }
+
+    public func colors(for feature: AnyFeature) -> FeatureStateColors {
+        return resolver(feature)
+    }
+}

--- a/Source/UI/FeaturesInteractor_iOS.swift
+++ b/Source/UI/FeaturesInteractor_iOS.swift
@@ -33,7 +33,9 @@ extension FeaturesInteractor { /* UITableViewDelegate */
                                                                completion: callback)
         }
 
-        action.backgroundColor = labeledFeature.feature.defaultState ? UIColor.mulah : UIColor.swedishFish
+        let colors = presenter.colorProvider.colors(for: labeledFeature.feature)
+        let backgroundColor = labeledFeature.feature.defaultState ? colors.enabledColor : colors.disabledColor
+        action.backgroundColor = backgroundColor
         return UISwipeActionsConfiguration(actions: [action])
     }
 
@@ -64,8 +66,9 @@ extension FeaturesInteractor { /* UITableViewDelegate */
                                                                    completion: callback)
         }
 
-        enableAction.backgroundColor = UIColor.mulah
-        disableAction.backgroundColor = UIColor.swedishFish
+        let colors = presenter.colorProvider.colors(for: labeledFeature.feature)
+        enableAction.backgroundColor = colors.enabledColor
+        disableAction.backgroundColor = colors.disabledColor
 
         var actions: [UIContextualAction]
         switch labeledFeature.feature.override {

--- a/Source/UI/FeaturesPresenter.swift
+++ b/Source/UI/FeaturesPresenter.swift
@@ -27,11 +27,15 @@ class FeaturesPresenter: NSObject, UITableViewDataSource {
 
     var features: [LabeledItem] { filteredFeatures ?? allFeatures }
 
+    let colorProvider: FeatureStateColorProvider
+
     private let allFeatures: [LabeledItem]
     private var filteredFeatures: [LabeledSearchResultItem]?
 
-    init(withFeatures features: [LabeledItem]) {
+    init(withFeatures features: [LabeledItem],
+         colorProvider: FeatureStateColorProvider) {
         self.allFeatures = features
+        self.colorProvider = colorProvider
     }
 
     /// If the feature require restart (see `featuresRequiringRestart`), presents
@@ -77,7 +81,8 @@ extension FeaturesPresenter { /* UITableViewDataSource */
             let cellID = FeaturesTableViewController.FeatureCellIdentifier.switchCell.rawValue
             let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath)
             if let cell = cell as? FeatureSwitchCell {
-                cell.labeledFeature = item.result
+                cell.configure(with: item.result,
+                               colorProvider: colorProvider)
                 cell.featurePath = item.groupStack
             }
             return cell
@@ -87,7 +92,8 @@ extension FeaturesPresenter { /* UITableViewDataSource */
             let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath)
 
             if let cell = cell as? FeatureSwitchCell {
-                cell.labeledFeature = labeledItem as? LabeledFeatureItem
+                cell.configure(with: labeledItem as? LabeledFeatureItem,
+                               colorProvider: colorProvider)
             }
             return cell
         }
@@ -140,7 +146,8 @@ extension FeaturesPresenter { /* UITableViewController Support Methods */
 
     func present(_ tableView: UITableView, groupAtIndexPath indexPath: IndexPath) {
         guard let labeledGroup = features[indexPath.row] as? LabeledGroupItem else { return }
-        let groupTableViewController = FeaturesTableViewController(features: labeledGroup)
+        let groupTableViewController = FeaturesTableViewController(features: labeledGroup,
+                                                                   colorProvider: colorProvider)
 
         if let navController = output?.navigationController {
             navController.pushViewController(groupTableViewController, animated: true)

--- a/Source/UI/FeaturesTableViewController.swift
+++ b/Source/UI/FeaturesTableViewController.swift
@@ -15,10 +15,15 @@ import UIKit
 
     let interactor: FeaturesInteractor
 
-    init<C: Collection>(features: C) where C.Element == LabeledItem {
+    let colorProvider: FeatureStateColorProvider
+
+    init<C: Collection>(features: C,
+                        colorProvider: FeatureStateColorProvider? = nil) where C.Element == LabeledItem {
         let arrayFeatures = Array(features)
 
-        presenter = FeaturesPresenter(withFeatures: arrayFeatures)
+        self.colorProvider = colorProvider ?? DefaultFeatureStateColorProvider()
+        presenter = FeaturesPresenter(withFeatures: arrayFeatures,
+                                      colorProvider: self.colorProvider)
         interactor = FeaturesInteractor(withPresenter: presenter)
 
         super.init(style: UITableView.Style.plain)
@@ -91,9 +96,11 @@ extension FeaturesTableViewController {
     /// allows use of this table view controller without the navigation
     /// controller provided by FeaturesViewController.
     ///
-    /// - Parameter featureRegistry: The feature registry to use
-    convenience init(featureRegistry: FeatureRegistry) {
-        self.init(features: featureRegistry.features)
+    /// - Parameters:
+    ///   - featureRegistry: The feature registry to use
+    ///   - colorProvider: Optional color provider for customizing feature state colors
+    convenience init(featureRegistry: FeatureRegistry, colorProvider: FeatureStateColorProvider? = nil) {
+        self.init(features: featureRegistry.features, colorProvider: colorProvider)
     }
 }
 
@@ -103,8 +110,10 @@ public extension FeaturesTableViewController {
     /// allows use of this table view controller without the navigation
     /// controller provided by FeaturesViewController.
     ///
-    /// - Parameter featureRegistry: The feature registry to use
-    convenience init(registry: FeatureRegistry) {
-        self.init(features: registry.features)
+    /// - Parameters:
+    ///   - registry: The feature registry to use
+    ///   - colorProvider: Optional color provider for customizing feature state colors
+    convenience init(registry: FeatureRegistry, colorProvider: FeatureStateColorProvider? = nil) {
+        self.init(features: registry.features, colorProvider: colorProvider)
     }
 }


### PR DESCRIPTION
## Description
Adds customizable color provider support for feature state colors in FeaturesTableViewController. Allows developers to customize the colors used for enabled and disabled feature states on a per-feature basis, making it easier to visually distinguish between different types of feature flags (e.g., server-side vs client-side flags).

Practical Example:
- Server-side feature flags: Blue (enabled) / Orange (disabled)
- Client-side feature flags: Green (enabled) / Red (disabled)
- Experimental features: Purple (enabled) / Gray (disabled)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested and ensured that the colors are updated and propagated correctly. 

**Note on Automated Tests:**
I was unable to add or run automated tests as they no longer build due to Nimble being out of date. The specific issue seems to be related to: https://github.com/Quick/Nimble/issues/1061. There are a number of breaking changes over the years so updating is a rather large task that should be handled separately.

## Screenshots (if appropriate):
Created with the following: 
```swift
ClosureFeatureStateColorProvider { feature in
    if feature.key?.hasPrefix("_") == true {
        return FeatureStateColors(enabledColor: .blue, disabledColor: .orange)
    } else {
        return FeatureStateColors.defaultStateColors
    }
}
```
<img width="230" height="500" alt="Simulator Screenshot - iPhone 16 - 2025-11-18 at 15 16 26" src="https://github.com/user-attachments/assets/4ae6a67a-01d1-4502-b534-572503f8a8c3" />

<img width="230" height="500" alt="Simulator Screenshot - iPhone 16 - 2025-11-18 at 15 18 18" src="https://github.com/user-attachments/assets/16e31d60-a17e-4a70-92f2-50783ae18054" />

<img width="230" height="500" alt="Simulator Screenshot - iPhone 16 - 2025-11-18 at 15 18 08" src="https://github.com/user-attachments/assets/d47cfd7c-9776-479e-b9c9-db32922e0948" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
